### PR TITLE
Fix invocation of perl using env call

### DIFF
--- a/bib2xhtml.pl
+++ b/bib2xhtml.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 # -*- perl -*-
 # vim: syntax=perl
 eval 'exec /usr/bin/perl -w -S $0 ${1+"$@"}'
@@ -23,7 +23,7 @@ $version = '@VERSION@';
 # an appropriate editor, if you want to view/modify the LaTeX to Unicode
 # substitution commands.
 #
-
+use warnings;
 use Getopt::Std;
 use open IO => ':crlf';
 

--- a/gen-bst.pl
+++ b/gen-bst.pl
@@ -1,6 +1,7 @@
-#!/usr/bin/env perl -w
+#!/usr/bin/env perl
 #
 #
+use warnings;
 
 $DEFS = "html-btxbst.doc";
 


### PR DESCRIPTION
The current shebang in the script doesn't work with the "env" call.

I have replaced it with a standard env call, and added "use warnings" to activate warnings instead.