### PR TITLE
Fix portability of multiple arguments for /usr/bin/perl

### DIFF
--- a/bibsearch.pl
+++ b/bibsearch.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl -T -w
+#!/usr/bin/perl -T
 
 # $Id: bibsearch,v 1.20 1998/02/11 19:22:30 hull Exp hull $
 #
@@ -33,6 +33,7 @@
 #
 
 ### Configuration section.
+use warnings;
 
 # Path of default bibliography database, if not specified in URL.
 $DEFAULT_BIB_PATH = "/usr/dcs/www/www-root/papers/index.html";


### PR DESCRIPTION
Similar to the fixes for /usr/bin/env, since these arguments are required for these scripts to run properly, we can't use /usr/bin/env, but only a single argument is supported (portably for BSD vs Linux)